### PR TITLE
add package.json files

### DIFF
--- a/node_modules/denon-avr/package.json
+++ b/node_modules/denon-avr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "denon-avr",
+  "version": "1.0.0",
+  "description": "Denon HEOS/AVR Connector",
+  "main": "index.js",
+  "scripts": {
+  },
+  "author": {
+    "name": "Ramón Baas"
+  },
+  "license": "ISC",
+  "dependencies": {
+  },
+  "readmeFilename": "README.md",
+  "_id": "denon-avr@1.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.soundunited.heos",
+  "version": "1.1.3",
+  "description": "Control your Denon/Marantz Heos devices with Homey.",
+  "main": "app.js",
+  "dependencies": {
+    "denon-avr": "^1.0.0",
+    "denon-heos": "^1.0.1"
+  },
+  "author": "Ramón Baas",
+  "license": "ISC",
+  "homepage": "https://https://github.com/nlrb/com.soundunited.heos#readme"
+}


### PR DESCRIPTION
the new CLI installer of Athom makes it so any node modules that aren't in the package.json file aren't send at all to Homey and thus failing the installation.
This will add them so your (awesome) app will also install in the latest CLI version.